### PR TITLE
Add Anderson Network cross-reference to the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,11 @@
     footer{position:relative;z-index:2;border-top:1px solid var(--line);padding:30px 0;color:var(--muted);font-size:.9rem}
     .foot{display:flex;justify-content:space-between;align-items:center;gap:14px;flex-wrap:wrap}
     .foot a:hover{color:var(--ink)}
+    .net{margin-top:22px;padding-top:22px;border-top:1px solid var(--line);color:var(--muted)}
+    .net-title{font-size:.78rem;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--muted);margin-bottom:12px}
+    .net-links{display:flex;flex-wrap:wrap;gap:8px 18px}
+    .net-links a{color:var(--muted)}
+    .net-links a:hover{color:var(--ink)}
     @media(max-width:760px){.grid{grid-template-columns:1fr}}
   </style>
 </head>
@@ -97,10 +102,27 @@
     <p style="margin-top:18px;font-size:.9rem">Or email <a href="mailto:hello@rubiconit.ca" style="color:var(--accent)">hello@rubiconit.ca</a> <!-- TODO: real address --></p>
   </div></div></section>
   <!-- ====== EDIT COPY ABOVE ====== -->
-  <footer><div class="wrap foot">
-    <div>© <span id="y"></span> Rubicon IT</div>
-    <div>rubiconit.ca</div>
-  </div></footer>
+  <footer>
+    <div class="wrap foot">
+      <div>© <span id="y"></span> Rubicon IT</div>
+      <div>rubiconit.ca</div>
+    </div>
+    <div class="wrap net">
+      <div class="net-title">The Anderson Network</div>
+      <div class="net-links">
+        <a href="https://richereverydayineveryway.com" target="_blank" rel="noopener">King Legend Venture Studios</a>
+        <a href="https://axai.ca" target="_blank" rel="noopener">AXAI Innovations</a>
+        <a href="https://rubiconnexus.com" target="_blank" rel="noopener">Rubicon Nexus</a>
+        <a href="https://juge.ca" target="_blank" rel="noopener">Juge.ca</a>
+        <a href="https://judge911.com" target="_blank" rel="noopener">Judge911</a>
+        <a href="https://justicesansfrontieres.ca" target="_blank" rel="noopener">Justice Sans Frontières</a>
+        <a href="https://impactnarrativemedia.com" target="_blank" rel="noopener">Impact Narrative Media</a>
+        <a href="https://pvthostel.com" target="_blank" rel="noopener">PVT Hostel</a>
+        <a href="https://bunkmate.app" target="_blank" rel="noopener">Bunkmate</a>
+        <a href="https://intentregistry.io" target="_blank" rel="noopener">Intent Network</a>
+      </div>
+    </div>
+  </footer>
   <script>document.getElementById('y').textContent=new Date().getFullYear();</script>
 </body>
 </html>


### PR DESCRIPTION
Extends the Anderson Network Standard: a footer row linking every ecosystem site up to the King Legend hub. Additive only.