### PR TITLE
feat: notify users when a new version is deployed

### DIFF
--- a/api/version.js
+++ b/api/version.js
@@ -1,0 +1,13 @@
+// Vercel serverless function — live-deployment version probe for static sites.
+// Returns the commit this deployment was built from (VERCEL_GIT_COMMIT_SHA,
+// available at runtime). The inline notifier script records it on load and polls
+// for a change. Never cached. CommonJS (these repos have no package.json).
+module.exports = function handler(req, res) {
+  res.setHeader(
+    "Cache-Control",
+    "no-store, no-cache, must-revalidate, max-age=0"
+  );
+  res
+    .status(200)
+    .json({ commit: process.env.VERCEL_GIT_COMMIT_SHA || "local" });
+};

--- a/index.html
+++ b/index.html
@@ -124,5 +124,55 @@
     </div>
   </footer>
   <script>document.getElementById('y').textContent=new Date().getFullYear();</script>
+    <!-- New-version notifier: records the deployed commit on load, polls /api/version,
+         and offers a one-click refresh when a newer deployment ships. -->
+    <script>
+      (function () {
+        var loaded = null, dismissed = null, el = null;
+        function show(commit) {
+          if (el) return;
+          el = document.createElement("div");
+          el.setAttribute("role", "status");
+          el.setAttribute("aria-live", "polite");
+          el.style.cssText =
+            "position:fixed;bottom:20px;left:50%;transform:translateX(-50%);z-index:99999;display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:10px 18px;max-width:min(94vw,540px);padding:14px 18px;border-radius:14px;background:#111827;border:1px solid rgba(255,255,255,.12);box-shadow:0 18px 50px -18px rgba(0,0,0,.6);color:#f9fafb;font:600 .95rem/1.4 system-ui,-apple-system,Segoe UI,sans-serif";
+          var copy = document.createElement("span");
+          copy.style.cssText = "display:flex;flex-direction:column;gap:2px;min-width:0";
+          copy.innerHTML =
+            '<span>A new version of the site is available.</span><span style="font-size:.8rem;font-weight:400;color:#9ca3af">Updating takes less than 5 seconds.</span>';
+          var actions = document.createElement("span");
+          actions.style.cssText = "display:flex;gap:8px;flex-shrink:0";
+          var up = document.createElement("button");
+          up.type = "button"; up.textContent = "Update";
+          up.style.cssText =
+            "cursor:pointer;border:none;border-radius:999px;padding:9px 18px;font:600 .9rem system-ui;background:#f9fafb;color:#111827";
+          up.onclick = function () { window.location.reload(); };
+          var no = document.createElement("button");
+          no.type = "button"; no.textContent = "Later";
+          no.style.cssText =
+            "cursor:pointer;border-radius:999px;padding:9px 14px;font:.9rem system-ui;background:transparent;border:1px solid rgba(255,255,255,.18);color:#9ca3af";
+          no.onclick = function () { dismissed = commit; if (el) { el.remove(); el = null; } };
+          actions.appendChild(up); actions.appendChild(no);
+          el.appendChild(copy); el.appendChild(actions);
+          document.body.appendChild(el);
+        }
+        function check() {
+          fetch("/api/version", { cache: "no-store" })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (j) {
+              if (!j || !j.commit) return;
+              if (loaded === null) { loaded = j.commit; return; }
+              if (j.commit !== loaded && j.commit !== dismissed) show(j.commit);
+            })
+            .catch(function () {});
+        }
+        setTimeout(check, 15000);
+        setInterval(check, 180000);
+        document.addEventListener("visibilitychange", function () {
+          if (document.visibilityState === "visible") check();
+        });
+        window.addEventListener("focus", check);
+      })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## What

Adds the **version-update notifier** in a static-site-friendly form (this repo is a `framework: null` static `index.html` on Vercel, so the React/route-handler variant used on the Next.js sites doesn't apply).

## How

- **`api/version.js`** — a Vercel serverless function (auto-deployed for static projects) that returns `{ commit: VERCEL_GIT_COMMIT_SHA }` with `Cache-Control: no-store`.
- **Inline script** (before `</body>` in `index.html`) — records the deployed commit on first load, polls `/api/version` every 3 min (plus on tab focus/visibility), and when a newer deployment's commit appears, shows a small dismissible **Update** banner that reloads the page.

No build step, no dependencies — works on the existing static deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
